### PR TITLE
Add support for Visual Studio Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Chromodynamics [![apm](https://img.shields.io/apm/dm/chromodynamics.svg?label=Atom)](https://atom.io/themes/chromodynamics) [![Package Control](https://img.shields.io/packagecontrol/dt/Color%20Scheme%20-%20Chromodynamics.svg?label=Sublime%20Text)](https://packagecontrol.io/packages/Color%20Scheme%20-%20Chromodynamics)
+# Chromodynamics [![apm](https://img.shields.io/apm/dm/chromodynamics.svg?label=Atom)](https://atom.io/themes/chromodynamics) [![Package Control](https://img.shields.io/packagecontrol/dt/Color%20Scheme%20-%20Chromodynamics.svg?label=Sublime%20Text)](https://packagecontrol.io/packages/Color%20Scheme%20-%20Chromodynamics)[![Visual Studio Marketplace](https://vsmarketplacebadge.apphb.com/installs-short/magicstack.Chromodynamics.svg?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=magicstack.Chromodynamics)
 
-This is a color theme for Sublime Text and Atom.
+This is a color theme for Sublime Text, Atom and VS Code.
 
 ![](https://magicstack.github.io/MagicPython/example.png)
 
@@ -15,3 +15,5 @@ In **Sublime Text** install the `Chromodynamics` package with "Package Control".
 
 In **Atom** find the `Chromodynamics` theme, install it, and enable via
 `Themes / Syntax Theme`.
+
+In **VS Code**, install the `Chromodynamics` theme with the `Install Extensions` command or type `ext install magicstack.Chromodynamics` in the Quick Open sheet. 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,25 @@
 {
   "name": "Chromodynamics",
+  "publisher": "magicstack",
   "theme": "syntax",
   "version": "0.0.11",
   "description": "Syntax Theme",
   "repository": "https://github.com/MagicStack/Chromodynamics",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.13.0"
+    "atom": ">=1.13.0",
+    "vscode": "^1.15.0"
+  },
+  "categories": [
+    "Themes"
+  ],
+  "contributes": {
+    "themes": [
+      {
+        "label": "Chromodynamics",
+        "uiTheme": "vs-dark",
+        "path": "./themes/Chromodynamics-color-theme.json"
+      }
+    ]
   }
 }

--- a/themes/Chromodynamics-color-theme.json
+++ b/themes/Chromodynamics-color-theme.json
@@ -1,0 +1,12 @@
+{
+	"tokenColors": "../Chromodynamics.tmTheme",
+	"colors": {
+		"editor.background": "#060606",
+		"editorCursor.foreground": "#dfdfdf",
+		"editor.foreground": "#c6c6c6",
+		"editorWhitespace.foreground": "#3B3A32",
+		"editor.lineHighlightBackground": "#252525",
+		"editor.selectionBackground": "#444"
+	},
+	"name": "Chromodynamics"
+}


### PR DESCRIPTION
This PR adds support for Visual Studio Code. 

Tested on the latest version, VS Code 1.15.1. 

I've taken the liberty to also add your VS Code Marketplace identifier `magicstack` used with MagicPython to the badges to make publishing easier. 

One caveat I can think of, is the `colors` dictionary in [themes/Chromodynamics-color-theme.json](themes/Chromodynamics-color-theme.json). The colors mentioned there are not dynamically loaded from the style file. 